### PR TITLE
Ribbon plot now supports global properties

### DIFF
--- a/ocean.py
+++ b/ocean.py
@@ -469,7 +469,7 @@ class Depth:
     data_full = depth.combined_scan.data.copy()
 
     for d in depth.detsums:
-      get_threshold = filter_dict[element]
+      get_threshold = filter_dict[d.element]
       # Make sure filter_funcs are working properly.
       if not isinstance(get_threshold(test_arr), float):
         raise TypeError('Problem encountered with filter function for {d.element}. '

--- a/plotting.py
+++ b/plotting.py
@@ -92,7 +92,7 @@ def save_new_props(element_groups, dir_name=None):
   for group in element_groups:
     if group in prop_map:
       continue
-    prop_map.update(group=available_props.pop(0))
+    prop_map.update({group: available_props.pop(0)})
 
   # Re-save available_props (now with fewer available)
   with open(available_fname, 'w') as f:

--- a/plotting.py
+++ b/plotting.py
@@ -22,7 +22,8 @@ def _create_prop_list(dir_name=None, overwrite=False):
 
   fname = 'available_props.json'
   if dir_name is not None:
-    os.makedirs(dir_name)
+    if not os.path.isdir(dir_name):
+      os.makedirs(dir_name)
     fname = os.path.join(dir_name, fname)
 
   # Get a default list of 10 colors. I don't exactly understand *how* this

--- a/plotting.py
+++ b/plotting.py
@@ -170,7 +170,7 @@ def ribbon_plot(depths,
   depths = sorted(depths, key=lambda d: int(d.depth[:-1]), reverse=True)
 
   if not _prop_list_exists(experiment_dir):
-    _create_prop_list(dir_Name=experiment_dir, overwrite=True)
+    _create_prop_list(dir_name=experiment_dir, overwrite=True)
 
   if normalize_by == 'pixels':
     sort_by = 'num_pixels'
@@ -254,7 +254,7 @@ def ribbon_plot(depths,
   # https://stackoverflow.com/questions/53849888/make-patches-bigger-used-as-legend-inside-matplotlib
   patches = []
   for group in these_props:
-    patches.append(mpatches.Patch( **these_props[group], label=group))
+    patches.append(mpatches.Patch(**these_props[group], label=group))
 
   leg = ax.legend(handles=patches,
                   bbox_to_anchor=(1, 1.2),

--- a/plotting.py
+++ b/plotting.py
@@ -72,6 +72,7 @@ def save_new_props(element_groups, dir_name=None):
     with open(map_fname, 'r') as f:
       prop_map = json.load(f)
   else:
+    os.makedirs(dir_name)
     prop_map = {}
   
 
@@ -96,8 +97,11 @@ def save_new_props(element_groups, dir_name=None):
   # Re-save available_props (now with fewer available)
   with open(available_fname, 'w') as f:
     json.dump(available_props, f)
-   
 
+  # Re-save new property map
+  with open(map_fname, 'w') as f:
+    json.dump(prop_map, f)
+   
 def get_single_prop(element_group, dir_name=None):
   '''Gets the property for the given element_group, if it exists.'''
 

--- a/plotting.py
+++ b/plotting.py
@@ -237,7 +237,7 @@ def ribbon_plot(depths,
   i=0
   yticklabels = []
   for depth in depths:
-    depth.apply_element_filter(element_filter, combine_detsums=combine_detsums, inplace=False)
+    depth.apply_element_filter(element_filter, combine_detsums=combine_detsums)
     if combine_scans:
       scans = [depth.combined_scan]
       yticklabels.append(depth.depth)

--- a/plotting.py
+++ b/plotting.py
@@ -206,7 +206,7 @@ def ribbon_plot(depths,
     groups = get_scan_groups(scan)
 
     # Save properties for these groups
-    save_new_props(groups, dir_name=experiment_dir)
+    save_new_props(groups.index, dir_name=experiment_dir)
 
     # If groups are empy, do nothing
     if not len(groups.index):

--- a/plotting.py
+++ b/plotting.py
@@ -22,6 +22,7 @@ def _create_prop_list(dir_name=None, overwrite=False):
 
   fname = 'available_props.json'
   if dir_name is not None:
+    os.makedirs(dir_name)
     fname = os.path.join(dir_name, fname)
 
   # Get a default list of 10 colors. I don't exactly understand *how* this

--- a/plotting.py
+++ b/plotting.py
@@ -72,7 +72,6 @@ def save_new_props(element_groups, dir_name=None):
     with open(map_fname, 'r') as f:
       prop_map = json.load(f)
   else:
-    os.makedirs(dir_name)
     prop_map = {}
   
 

--- a/plotting.py
+++ b/plotting.py
@@ -237,7 +237,7 @@ def ribbon_plot(depths,
   i=0
   yticklabels = []
   for depth in depths:
-    depth.apply_element_filter(element_filter, combine_detsums=combine_detsums)
+    depth.apply_element_filter(element_filter, combine_detsums=combine_detsums, inplace=False)
     if combine_scans:
       scans = [depth.combined_scan]
       yticklabels.append(depth.depth)


### PR DESCRIPTION
Up until now, each ribbon plot cycled through a local set of properties to assign each element group a specific color and pattern. Because of this, it was difficult to compare plots, as the colors and patterns did not necessarily align.

Properties are now stored in two separate json files, called "available_props.json" and "prop_map.json". The location of these files is controlled by a new `experiment_dir` option added to `ribbon_plot`.

```
def ribbon_plot(depths,
                element_filter,
                filter_by='Cu',
                combine_scans=True,
                combine_detsums=True,
                N=8,
                normalize_by='counts',
                base64=False,
                experiment_dir=None): <-------- HERE
```

## How it works

If `experiment_dir` is not explicitly assigned, then the current working directory will be used. If running inside Colab, this may be a path to a Google Drive directory or a directory on the local Colab machine. 

"available_props.json" contains available and unassigned properties. When first generated, this contains 340 different color / pattern combinations. "prop_map.json" contains a key, value mapping of the form `{<element_group>, props}` where `props` is a property set taken from "available_props.json". 

Every time a ribbon plot is run, element groups are generated based on the args passed in to `ribbon_plot`. The code then pulls a new property from "available_props" for each group that doesn't already exist in "prop_map". 

## Usage

These files are always generated; however, as mentioned above, if `experiment_dir` is _not_ explicitly passed, then it will default to the current working directory. If in Colab, this directory will not persist across different sessions, as the factory runtime will reset. 

The current best practice is to pass the root directory containing all Depth folders:
![image](https://user-images.githubusercontent.com/9022917/85032260-d9e46700-b13c-11ea-960d-44b44af2d493.png)

In the official notebook, this is currently stored in the global `EXPERIMENT_DIR` variable. By using this directory, it ensures that the properties will be consistent across *all* ribbon plots in *all* Colab sessions. 

### Different Experiments

There are two ways to maintain consistent properties across different experiments

1.  Copy "available_props.json" and "prop_map.json" to a different experiment folder
2. Point to the same folder in all `ribbon_plot` calls (by setting `experiment_dir`)

As the codebase is further developed, more best practices will emerge, but at this point, either option is equivalent.